### PR TITLE
add Clone support to Ruckig and ThrowErrorHandler

### DIFF
--- a/lib/src/rsruckig/calculator_target.rs
+++ b/lib/src/rsruckig/calculator_target.rs
@@ -21,7 +21,7 @@ use crate::{
 
 use crate::alloc::{vec, vec::Vec, format};
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct TargetCalculator<const DOF: usize> {
     eps: f64,
     return_error_at_maximal_duration: bool,

--- a/lib/src/rsruckig/error.rs
+++ b/lib/src/rsruckig/error.rs
@@ -95,7 +95,7 @@ pub trait RuckigErrorHandler {
     fn handle_calculator_error(message: &str) -> Result<(), RuckigError>;
 }
 
-#[derive(Debug, Default)]
+#[derive(Debug, Default, Clone)]
 pub struct ThrowErrorHandler;
 
 impl RuckigErrorHandler for ThrowErrorHandler {

--- a/lib/src/rsruckig/ruckig.rs
+++ b/lib/src/rsruckig/ruckig.rs
@@ -72,7 +72,7 @@ use crate::alloc::format;
 /// // Heap allocation (3 DoF)
 /// let mut otg = Ruckig::<0, ThrowErrorHandler>::new(Some(3), 0.01);
 /// ```
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Ruckig<const DOF: usize, E: RuckigErrorHandler> {
     current_input: InputParameter<DOF>,
     current_input_initialized: bool,


### PR DESCRIPTION
Suddently was in the need of cloning a ruckig object to try out feasibility of different axis direction alternatives.
If there is a reason Clone should no be used, let me know